### PR TITLE
fix(react): Failed prop type not between min/max

### DIFF
--- a/src/Components/Input/Slider/index.jsx
+++ b/src/Components/Input/Slider/index.jsx
@@ -77,7 +77,7 @@ function Slider({
             onChange={updateValue}
             onChangeComplete={handleUpdate}
             step={step}
-            value={inSync ? getDisplayValue() : 0}
+            value={inSync ? getDisplayValue() : min}
           />
         </div>
 


### PR DESCRIPTION
Fixes the following prop type error that can happen when minValue is higher than 0.

    index.js:1 Warning: Failed prop type: "value" must be in between "minValue" and "maxValue"
        at InputRange (http://localhost:3000/static/js/vendors~main.chunk.js:51922:5)