### PR TITLE
Use backdrop element to avoid closing dialog on drag

### DIFF
--- a/src/Components/App/style.scss
+++ b/src/Components/App/style.scss
@@ -394,3 +394,12 @@ body {
     display: block;
   }
 }
+
+.backdrop {
+  background: rgba(0, 0, 0, 0.75);
+  position: fixed;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  left: 0;
+}

--- a/src/Components/AppSettings/index.jsx
+++ b/src/Components/AppSettings/index.jsx
@@ -13,10 +13,6 @@ function AppSettings({
 }) {
   const { t } = useTranslation('settings');
 
-  function handleChildClick(e) {
-    e.stopPropagation();
-  }
-
   function handleCheckboxChange(e) {
     const name = e.target.name;
     const value = e.target.checked;
@@ -47,11 +43,14 @@ function AppSettings({
   return (
     <div
       className="settings"
-      onClick={onClose}
     >
       <div
+        className="backdrop"
+        onClick={onClose}
+      />
+    
+      <div
         className="settings__wrapper"
-        onClick={handleChildClick}
       >
         <div
           className="settings__close"

--- a/src/Components/AppSettings/style.scss
+++ b/src/Components/AppSettings/style.scss
@@ -1,5 +1,4 @@
 .settings {
-  background: rgba(0, 0, 0, 0.75);
   position: fixed;
   width: 100%;
   height: 100%;

--- a/src/Components/MelodyEditor/index.jsx
+++ b/src/Components/MelodyEditor/index.jsx
@@ -228,10 +228,6 @@ function MelodyEditor({
     setAcceptedMelodies([...acceptedMelodies]);
   }
 
-  function handleChildClick(e) {
-    e.stopPropagation();
-  }
-
   function handleSave() {
     setCurrentMelodies([...acceptedMelodies]);
     onWrite(acceptedMelodies);
@@ -330,13 +326,14 @@ function MelodyEditor({
   });
 
   return (
-    <div
-      id="melody-editor"
-      onClick={handleClose}
-    >
+    <div id="melody-editor">
+      <div
+        className="backdrop"
+        onClick={handleClose}
+      />
+
       <div
         className="melody-editor-wrapper"
-        onClick={handleChildClick}
       >
         <div
           className="close"

--- a/src/Components/MelodyEditor/style.scss
+++ b/src/Components/MelodyEditor/style.scss
@@ -1,5 +1,4 @@
 #melody-editor {
-  background: rgba(0, 0, 0, 0.75);
   position: fixed;
   width: 100%;
   height: 100%;


### PR DESCRIPTION
When doing mouse down inside the melody editor and dragging the mouse outside the editor and then releasing, the melody editor closes.
This could happen e.g. when selecting melody text with the mouse.

This fixes the issue, however now the editor is closed immediately on mousedown outside the editor. 
I think this is okay but it would be nice if it could be fixed with the `onClick` event.