### PR TITLE
Pre-select current ESC firmware

### DIFF
--- a/src/Components/FirmwareSelector/__tests__/index.test.jsx
+++ b/src/Components/FirmwareSelector/__tests__/index.test.jsx
@@ -73,14 +73,18 @@ describe('FirmwareSelector', () => {
     const onLocalSubmit = jest.fn();
     const onCancel = jest.fn();
 
+    const escMock = {
+      settings: { LAYOUT: "#S_H_90#" },
+      meta: { signature: 0xE8B2 },
+    };
+
     const { container } = render(
       <FirmwareSelector
         configs={configs}
-        escHint="#S_H_90#"
+        esc={escMock}
         onCancel={onCancel}
         onLocalSubmit={onLocalSubmit}
         onSubmit={onSubmit}
-        signatureHint={59570}
       />
     );
 
@@ -182,14 +186,18 @@ describe('FirmwareSelector', () => {
     const onLocalSubmit = jest.fn();
     const onCancel = jest.fn();
 
+    const escMock = {
+      settings: { LAYOUT: "T-MOTOR 55A" },
+      meta: { signature: 0x1F06 },
+    };
+
     render(
       <FirmwareSelector
         configs={configs}
-        escHint="T-MOTOR 55A"
+        esc={escMock}
         onCancel={onCancel}
         onLocalSubmit={onLocalSubmit}
         onSubmit={onSubmit}
-        signatureHint={7942}
       />
     );
 

--- a/src/Components/FirmwareSelector/index.jsx
+++ b/src/Components/FirmwareSelector/index.jsx
@@ -64,11 +64,10 @@ function FirmwareSelector({
 
     const currentFirmware = validFirmware.find((name) => esc.firmwareName === name);
 
-    const newSelection = {
+    setSelection({
       ...selection,
       firmware: currentFirmware || validFirmware[0],
-    };
-    setSelection(newSelection);
+    });
 
     setValidFirmware(validFirmware);
     setMode(selectedMode);
@@ -146,13 +145,11 @@ function FirmwareSelector({
   function handleFirmwareChange(e) {
     const firmware = e.target.value;
 
-    const newSelection = {
+    setSelection({
       firmware,
       url: null,
       pwm: null,
-    };
-
-    setSelection(newSelection);
+    });
   }
 
   function handleEscChange(e) {
@@ -168,12 +165,11 @@ function FirmwareSelector({
     const selected = e.target.options.selectedIndex;
     const selecteOption = e.target.options[selected];
 
-    const newSelection = {
+    setSelection({
       ...selection,
       url: e.target.value,
       version: selecteOption ? selecteOption.text : 'N/A',
-    };
-    setSelection(newSelection);
+    });
   }
 
   function handleForceChange(e) {
@@ -185,11 +181,10 @@ function FirmwareSelector({
   }
 
   function handlePwmChange(e) {
-    const newSelection = {
+    setSelection({
       ...selection,
       pwm: e.target.value,
-    };
-    setSelection(newSelection);
+    });
   }
 
   function handleSubmit() {

--- a/src/Components/MainContent/index.jsx
+++ b/src/Components/MainContent/index.jsx
@@ -139,12 +139,11 @@ function MainContent({
           <div className="content_wrapper">
             <FirmwareSelector
               configs={configs}
-              escHint={esc ? esc.settings.LAYOUT : null}
+              esc={esc}
               onCancel={onCancelFirmwareSelection}
               onLocalSubmit={onLocalSubmit}
               onSubmit={onFlashUrl}
               showWarning={esc ? true : false}
-              signatureHint={esc ? esc.meta.signature : null}
               warning={warning}
             />
           </div>

--- a/src/changelog.json
+++ b/src/changelog.json
@@ -2,14 +2,15 @@
   {
     "title": "unreleased",
     "items": [
+      "Enhancement: Pre-select current ESC firmware when flashing",
       "Enhancement: Cache firmware versions and layouts - do not store them in the app",
-      "Enhancement: Diable connect/disconnect button when app not idle",
+      "Enhancement: Disable connect/disconnect button when app not idle",
       "Enhancement: Added more melodies",
       "Wording: Normalized ESCs and BLHeli_S",
       "Bugfix: Fixed min/max properties with slider",
       "Bugfix: Dump the proper ESC instead of defaulting to the last one",
       "Bugfix: Update the proper ESC after flashing a single ESC",
-      "Refactor: Removed firmware and ESC files - use the ones from the coresponding repository instead",
+      "Refactor: Removed firmware and ESC files - use the ones from the corresponding repository instead",
       "Refactor: Overlay component",
       "Refactor: Simplified firmware sources",
       "Chore: Bluejay settings cleanup",

--- a/src/utils/FourWay.js
+++ b/src/utils/FourWay.js
@@ -274,6 +274,7 @@ class FourWay {
         let defaultSettings = blheliEeprom.DEFAULTS;
         let validFirmwareNames = blheliEeprom.NAMES;
         let displayName = 'UNKNOWN';
+        let firmwareName = 'UNKNOWN';
 
         if (isSiLabs) {
           layoutSize = blheliEeprom.LAYOUT_SIZE;
@@ -390,9 +391,11 @@ class FourWay {
             }
 
             displayName = `${make} - JESC, ${revision}`;
+            firmwareName = 'JESC';
           } else if (bluejayEeprom.NAMES.includes(name) && layoutName in bluejayLayouts) {
             make = bluejayLayouts[layoutName].name;
             displayName = bluejaySource.buildDisplayName(flash, make);
+            firmwareName = bluejaySource.getName();
           } else if (layoutName in blheliSilabsLayouts) {
             make = blheliSilabsLayouts[layoutName].name;
           } else if (layoutName in blheliSLayouts) {
@@ -465,6 +468,7 @@ class FourWay {
             }
 
             displayName = blheliSSource.buildDisplayName(flash, make);
+            firmwareName = blheliSSource.getName();
           }
         } else if (isArm) {
           /* Read version information direct from EEPROM so we can later
@@ -507,6 +511,7 @@ class FourWay {
           flash.settings.LAYOUT = flash.settings.NAME;
 
           displayName = am32Source.buildDisplayName(flash, flash.settings.NAME);
+          firmwareName = am32Source.getName();
         } else {
           const blheliAtmelLayouts = blheliSource.getEscLayouts();
           if (layoutName in blheliAtmelLayouts) {
@@ -517,6 +522,7 @@ class FourWay {
         flash.canMigrateTo = validFirmwareNames;
         flash.defaultSettings = defaultSettings[layoutRevision];
         flash.displayName = displayName;
+        flash.firmwareName = firmwareName;
         flash.layoutSize = layoutSize;
         flash.layout = layout;
         flash.make = make;


### PR DESCRIPTION
Currently the initial firmware selection is the first checked that the ESC supports, e.g. Bluejay.
This PR makes it so that the firmware currently on the ESC is used as initial selection, e.g. BLHeli_S.

I needed to pass the firmware name to the firmware selector component, but ended up passing the whole esc object and removing `escHint` and `signatureHint` because I thought it was simpler, but maybe that is not preferred?