### PR TITLE
Update melody accept button for empty string

### DIFF
--- a/src/Components/MelodyEditor/MelodyElement/index.jsx
+++ b/src/Components/MelodyEditor/MelodyElement/index.jsx
@@ -49,53 +49,51 @@ const MelodyElement = forwardRef(({
   }, [melody]);
 
   useEffect(() => {
-    if(currentMelody) {
-      try {
-        const response = Rtttl.toBluejayStartupMelody(currentMelody);
-        const errors = response.errorCodes;
-        const notes = currentMelody.split(':')[2].split(',');
+    try {
+      const response = Rtttl.toBluejayStartupMelody(currentMelody);
+      const errors = response.errorCodes;
+      const notes = currentMelody.split(':')[2].split(',');
 
-        const wrongNotes = [];
-        const tooLongNotes = [];
-        for(let i = 0; i < errors.length; i += 1) {
-          switch(errors[i]) {
-            case 1: {
-              wrongNotes.push(notes[i].replace(',', ''));
-            } break;
+      const wrongNotes = [];
+      const tooLongNotes = [];
+      for(let i = 0; i < errors.length; i += 1) {
+        switch(errors[i]) {
+          case 1: {
+            wrongNotes.push(notes[i].replace(',', ''));
+          } break;
 
-            case 2: {
-              tooLongNotes.push(i);
-            } break;
-          }
+          case 2: {
+            tooLongNotes.push(i);
+          } break;
         }
-
-        const highlight = [];
-        const uniqueWrongNotes = [ ...new Set(wrongNotes)];
-        highlight.push(uniqueWrongNotes);
-
-        if(tooLongNotes.length > 0) {
-          const elements = currentMelody.split(':');
-          const notes = elements[2].split(',');
-          let offset = elements[0].length + elements[1].length + 2;
-          for(let i = 0; i < tooLongNotes[0]; i += 1) {
-            offset += notes[i].length + 1;
-          }
-
-          highlight.push([offset - 1, currentMelody.length]);
-        }
-
-        setHighlight(highlight);
-
-        const isValid = uniqueWrongNotes.length === 0 && tooLongNotes.length === 0;
-        setIsValid(isValid);
-        setIsPlayable(true);
-      } catch(e) {
-        setIsPlayable(false);
-        setIsValid(false);
       }
 
-      onUpdate(currentMelody);
+      const highlight = [];
+      const uniqueWrongNotes = [ ...new Set(wrongNotes)];
+      highlight.push(uniqueWrongNotes);
+
+      if(tooLongNotes.length > 0) {
+        const elements = currentMelody.split(':');
+        const notes = elements[2].split(',');
+        let offset = elements[0].length + elements[1].length + 2;
+        for(let i = 0; i < tooLongNotes[0]; i += 1) {
+          offset += notes[i].length + 1;
+        }
+
+        highlight.push([offset - 1, currentMelody.length]);
+      }
+
+      setHighlight(highlight);
+
+      const isValid = uniqueWrongNotes.length === 0 && tooLongNotes.length === 0;
+      setIsValid(isValid);
+      setIsPlayable(true);
+    } catch(e) {
+      setIsPlayable(false);
+      setIsValid(false);
     }
+
+    onUpdate(currentMelody);
   }, [currentMelody]);
 
   function handleMelodyUpdate(e) {


### PR DESCRIPTION
In melody editor when e.g. removing all rtttl (so that the textbox is empty), currentMelody is an empty string and the accept button state is not updated. This allows clicking it which gives an error.

I updated it so it will also consider the empty string, but maybe it would be better to make an else case for `if(currentMelody)`? I'm not sure when/if currentMelody can be `null` or `undefined`?