### PR TITLE
Use tag for firmware version

### DIFF
--- a/src/Components/FirmwareSelector/index.jsx
+++ b/src/Components/FirmwareSelector/index.jsx
@@ -173,7 +173,7 @@ function FirmwareSelector({
     setSelection({
       ...selection,
       url: e.target.value,
-      version: selecteOption ? selecteOption.text : 'N/A',
+      version: selecteOption && options.versions[selected - 1].key,
     });
   }
 

--- a/src/sources/AM32/index.js
+++ b/src/sources/AM32/index.js
@@ -31,6 +31,8 @@ class AM32Source extends GithubSource {
   }) {
     const name = this.escs.layouts[escKey].name.replace(/[\s-]/g, '_').toUpperCase();
 
+    version = version.replace(/^v/, '');
+
     return `${url}${name}_${version}.hex`;
   }
 }

--- a/src/sources/Blheli/index.js
+++ b/src/sources/Blheli/index.js
@@ -16,7 +16,7 @@ class BLHeliSource extends Source {
   }
 
   getFirmwareUrl({
-    escKey, version, mode, url,
+    escKey, mode, url,
   }) {
     const format = (str2Format, ...args) =>
       str2Format.replace(/(\{\d+\})/g, (a) => args[+(a.substr(1, a.length - 2)) || 0]);

--- a/src/sources/Bluejay/index.js
+++ b/src/sources/Bluejay/index.js
@@ -45,7 +45,7 @@ class BluejaySource extends GithubSource {
   }) {
     const name = this.escs.layouts[escKey].name.replace(/[\s-]/g, '_').toUpperCase();
 
-    return `${url}${name}_${pwm}_v${version}.hex`;
+    return `${url}${name}_${pwm}_${version}.hex`;
   }
 }
 


### PR DESCRIPTION
Currently the firmware `version` passed to get hex url is based on the firmware version name.
This changes it to be based on the tag/key in order for AM32 and Bluejay pre-releases to work.

I thought I tested this for the github releases pr so not sure what happened.