### PR TITLE
Update eslint configuration

### DIFF
--- a/.babel.rc
+++ b/.babel.rc
@@ -1,5 +1,0 @@
-{
-  "presets": [
-    "@babel/preset-react"
-  ]
-}

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,13 +1,23 @@
 {
+  "parserOptions": {
+    "ecmaVersion": "latest",
+    "sourceType": "module",
+    "ecmaFeatures": { "jsx": true }
+  },
+  "env": {
+    "es2021": true,
+    "browser": true,
+    "node": true
+  },
   "extends": [
     "eslint:recommended",
     "plugin:react/all",
-    "plugin:jest/recommended"
+    "plugin:jest/recommended",
+    "react-app",
+    "react-app/jest"
   ],
   "ignorePatterns": ["service-worker.js"],
-  "plugins": [
-    "react"
-  ],
+  "plugins": ["react", "jest"],
   "rules": {
     "react/jsx-max-depth": ["warn", { "max": 5 }],
     "indent": ["warn", 2, { "SwitchCase": 1 }],
@@ -17,7 +27,12 @@
     "react/no-multi-comp": "off",
     "react/no-set-state": "off",
     "react/forbid-component-props": "off",
+    "react-hooks/rules-of-hooks": "warn",
+    "testing-library/no-container": "warn",
+    "testing-library/no-node-access": "warn",
     "no-unreachable": "off",
+    "no-lone-blocks": "off",
+    "no-mixed-operators": "off",
     "react/no-array-index-key": "warn",
     "react/no-danger": "warn",
     "no-unused-vars": "warn",
@@ -52,38 +67,6 @@
   "settings": {
     "react": {
       "version": "detect"
-    }
-  },
-  "globals": {
-    "document": false,
-    "process": false,
-    "navigator": false,
-    "console": false,
-    "fetch": false,
-    "URL": false,
-    "window": false,
-    "setInterval": false,
-    "clearInterval": false,
-    "Uint8Array": false,
-    "ArrayBuffer": false,
-    "DataView": false,
-    "setTimeout": false,
-    "clearTimeout": false,
-    "Promise": false,
-    "FileReader": false,
-    "Blob": false,
-    "localStorage": false,
-    "__dirname": false,
-    "require": false,
-    "Set": false,
-    "Event": false,
-    "global": false
-  },
-  "parser": "@babel/eslint-parser",
-  "parserOptions": {
-    "requireConfigFile": false,
-    "babelOptions": {
-      "presets": ["@babel/preset-react"]
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -72,7 +72,6 @@
   },
   "devDependencies": {
     "@babel/core": "^7.16.10",
-    "@babel/eslint-parser": "^7.16.5",
     "@babel/plugin-syntax-flow": "^7.16.7",
     "@babel/preset-react": "^7.16.7",
     "@testing-library/dom": "^8.11.2",
@@ -83,6 +82,7 @@
     "@typescript-eslint/parser": "^5.10.0",
     "codecov": "^3.8.3",
     "eslint": "^8.7.0",
+    "eslint-config-react-app": "^7.0.0",
     "eslint-plugin-jest": "^25.7.0",
     "eslint-plugin-react": "^7.28.0",
     "postcss": "^8.4.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -44,7 +44,7 @@
     semver "^6.3.0"
     source-map "^0.5.0"
 
-"@babel/eslint-parser@^7.16.3", "@babel/eslint-parser@^7.16.5":
+"@babel/eslint-parser@^7.16.3":
   version "7.16.5"
   resolved "https://registry.yarnpkg.com/@babel/eslint-parser/-/eslint-parser-7.16.5.tgz#48d3485091d6e36915358e4c0d0b2ebe6da90462"
   integrity sha512-mUqYa46lgWqHKQ33Q6LNCGp/wPR3eqOYTUixHFsfrSQqRxH0+WOzca75iEjFr5RDGH1dDz622LaHhLOzOuQRUA==


### PR DESCRIPTION
So this is basically my changes from #184 rebased onto develop.

I see that the `react-app` rules was removed so not sure if you want that back.
It gives some more warnings but since it's react I don't know if it's useful 😆 

Other than that the main change is to use env instead of globals and the default parser instead of babel.