### PR TITLE
Fix firmware url

### DIFF
--- a/src/sources/Bluejay/index.js
+++ b/src/sources/Bluejay/index.js
@@ -45,7 +45,7 @@ class BluejaySource extends GithubSource {
   }) {
     const name = this.escs.layouts[escKey].name.replace(/[\s-]/g, '_').toUpperCase();
 
-    if (settings.LAYOUT_REVISION >= 205) {
+    if (version === 'test-melody-pwm') {
       return `${url}${name}_${version}.hex`;
     }
 


### PR DESCRIPTION
The current idea of getting the new firmware name for eeprom 205 releases was to check if the release was using the 205 layout, however the implementation instead checks if the firmware currently installed is using it.

This is a quick fix to only use the new firmware naming for the test release on tag `test-melody-pwm`, since it is a bit complicated to tell if a version generally uses this.