### PR TITLE
Check that a valid layout is available, only then attempt to read the…

### DIFF
--- a/src/changelog.json
+++ b/src/changelog.json
@@ -8,6 +8,7 @@
       "Enhancement: Allow skipping cache for new releases",
       "Bugifx: Do not check for mistagging if JESC is detected",
       "Bugfix: Properly display flashed fail in ESC name",
+      "Bugfix: Allow re-flashing if firmware is broken",
       "Bugfix: Do not cut off hint text for melody sync checkbox"
     ]
   },

--- a/src/utils/FourWay.js
+++ b/src/utils/FourWay.js
@@ -439,8 +439,18 @@ class FourWay {
 
       // SiLabs EFM8 based
       if (info.isSiLabs) {
+        /**
+         * If we don't have a valid layout, something is wrong with the current
+         * firmware. It means the ESC can still be flashed, but we can't say
+         * for sure which firmware it is running
+         */
         const layouts = source.getEscLayouts();
-        make = layouts[layoutName].name;
+        const layout = layouts[layoutName];
+        if(!layout) {
+          source = null;
+        } else {
+          make = layout.name;
+        }
 
         if (source instanceof sources.BluejaySource) {
           info.displayName = source.buildDisplayName(info, make);


### PR DESCRIPTION
… layout. Otherwise something is wrong with the firmware, but ESC can still be flashed. Resolves #313