### PR TITLE
Do not allow reading/flashing when radio is detected to be turned on/…

### DIFF
--- a/src/Components/App/index.jsx
+++ b/src/Components/App/index.jsx
@@ -106,6 +106,7 @@ function App({
           onWriteSetup={escs.actions.handleWriteSetup}
           open={serial.open}
           port={serial.port}
+          radioOn={msp.radioOn}
           settings={escs.master}
         />
 
@@ -208,7 +209,10 @@ App.propTypes = {
     escs: PropTypes.arrayOf(PropTypes.string).isRequired,
     show: PropTypes.bool.isRequired,
   }).isRequired,
-  msp: PropTypes.shape({ features: PropTypes.shape({}).isRequired }).isRequired,
+  msp: PropTypes.shape({
+    features: PropTypes.shape({}).isRequired,
+    radioOn: PropTypes.func.isRequired,
+  }).isRequired,
   onAllMotorSpeed: PropTypes.func.isRequired,
   onClearLog: PropTypes.func.isRequired,
   onCookieAccept: PropTypes.func.isRequired,

--- a/src/Components/MainContent/index.jsx
+++ b/src/Components/MainContent/index.jsx
@@ -85,6 +85,7 @@ function MainContent({
   connected,
   fourWay,
   port,
+  radioOn,
 }) {
   const { t } = useTranslation('common');
   const {
@@ -102,7 +103,7 @@ function MainContent({
 
   const canWrite = (escs.length > 0) && !isSelecting && settings && !isFlashing && !isReading && !isWriting && !unsupported;
   const canFlash = (escs.length > 0) && !isSelecting && !isWriting && !isFlashing && !isReading && !disableFlashing;
-  const canRead = !isReading && !isWriting && !isSelecting && !isFlashing;
+  const canRead = !isReading && !isWriting && !isSelecting && !isFlashing && !radioOn;
   const showMelodyEditor = escs.length > 0 && escs[0].individualSettings.STARTUP_MELODY ? true : false;
 
   const FlashWrapper = useCallback(() => {
@@ -343,6 +344,7 @@ MainContent.propTypes = {
   open: PropTypes.bool,
   port: PropTypes.shape({ getBatteryState:PropTypes.func }),
   progress: PropTypes.arrayOf(PropTypes.number),
+  radioOn: PropTypes.bool.isRequired,
   settings: PropTypes.shape(),
 };
 

--- a/src/Containers/App/index.jsx
+++ b/src/Containers/App/index.jsx
@@ -40,7 +40,10 @@ class App extends Component {
     this.lastConnected = 0;
 
     this.state = {
-      msp: { features: {} },
+      msp: {
+        features: {},
+        radioOn: false,
+      },
       appSettings: {
         show: false,
         settings: loadSettings(),
@@ -793,6 +796,11 @@ class App extends Component {
       }
       this.addLogMessage('mspUid', { id: uidHex });
 
+      const status = await this.serial.getStatus();
+      if(!status.armingDisableFlagsReasons.RX_FAILSAFE) {
+        this.addLogMessage('radioOn');
+      }
+
       let motorData = await this.serial.getMotorData();
       motorData = motorData.filter((motor) => motor > 0);
 
@@ -810,7 +818,12 @@ class App extends Component {
         },
       });
 
-      this.setState({ msp: { features } });
+      this.setState({
+        msp: {
+          features,
+          radioOn: !status.armingDisableFlagsReasons.RX_FAILSAFE,
+        },
+      });
       this.setSerial({ open: true });
       this.setEscs({ connected: motorData.length });
     } catch(e) {

--- a/src/changelog.json
+++ b/src/changelog.json
@@ -1,5 +1,11 @@
 [
   {
+    "title": "Unreleased",
+    "items": [
+      "Enhancement: Detect if radio is on and do not allow reading/flashing"
+    ]
+  },
+  {
     "title": "0.28.1",
     "items": [
       "Chore: Fixed version"

--- a/src/translations/en/log.json
+++ b/src/translations/en/log.json
@@ -9,6 +9,7 @@
   "mspBuildInfo": "Running firmware released on: {{info}}",
   "mspBoardInfo": "Board: {{identifier}}, version: {{version}}",
   "mspUid": "Unique device ID received - 0x{{id}}",
+  "radioOn": "Your radio has been detected to be on! Reading and Flashing disabled. Turn off your radio and re-connect.",
   "mspFcInfo": "Flight controller info, identifier: {{id}} version: {{version}}",
   "portUsed": "Port already in use by another application - try re-connecting",
   "fourWayFailed": "Could not enable 4 way interface - reconnect flight controller",

--- a/src/utils/Msp.js
+++ b/src/utils/Msp.js
@@ -415,7 +415,21 @@ class Msp {
           config.i2cError = data.getUint16(2, 1);
           config.activeSensors = data.getUint16(4, 1);
           config.mode = data.getUint32(6, 1);
-          config.profile = data.getUint8(10);
+          config.currentProfile = data.getUint8(10);
+          config.averageSysytemLoadPercent = data.getUint16(11, 1);
+
+          config.pidProfileCount = data.getUint8(13);
+          config.currentRateProfile = data.getUint8(14);
+
+          config.byteCount = data.getUint8(15);
+
+          config.armingDisableFlagsCount = data.getUint8(16 + config.byteCount);
+          config.armingDisableFlags = data.getUint32(17 + config.byteCount, 1);
+
+          const rxFailsafe = (config.armingDisableFlags & (1 << 2)) === 0x04;
+          config.armingDisableFlagsReasons = { RX_FAILSAFE: rxFailsafe };
+
+          config.rebootRequired = data.getUint8(21 + config.byteCount);
 
           return config;
         }
@@ -726,6 +740,15 @@ class Msp {
    */
   getBoardInfo() {
     return this.send(MSP.MSP_BOARD_INFO);
+  }
+
+  /**
+   * Get Status
+   *
+   * @returns {Promise<MspStatus>}
+   */
+  getStatus() {
+    return this.send(MSP.MSP_STATUS);
   }
 
   /**

--- a/src/utils/Serial.js
+++ b/src/utils/Serial.js
@@ -237,6 +237,7 @@ class Serial {
   getFcVersion = () => this.msp.getFcVersion();
   getFeatures = () => this.msp.getFeatures();
   getMotorData = () => this.msp.getMotorData();
+  getStatus = () => this.msp.getStatus();
   getUid = () => this.msp.getUid();
   spinAllMotors = (speed) => this.msp.spinAllMotors(speed);
   spinMotor = (index, speed) => this.msp.spinMotor(index, speed);


### PR DESCRIPTION
…connected.

Use MSP_STATUS to detect failsafe state. If RX_FAILSAFE is NOT detected, it means that the radio is on and connected. Due to changes in BF 4.3.x and moving forward issues might arise - especially with SPI receivers - where the communication might get flaky. This seems to be due to changes in the scheduler and interrupt handling. This may lead to corrupted flashes resulting in soft or full brick of the ESCs (recovery only possible via C2 interface). This is considered to be a workaround. Other functionality where BF communicates with the ESC such as for example direction changes are also affected, but obviously there is nothing that can be done about that in esc-configurator.