### PR TITLE
add TYPE eeprom value and evaluate it for AM32

### DIFF
--- a/src/sources/AM32/eeprom.js
+++ b/src/sources/AM32/eeprom.js
@@ -4,7 +4,7 @@ const BOOT_LOADER_PINS = {
 };
 
 const RESET_DELAY_MS = 2500;
-const LAYOUT_SIZE = 0xB0;
+const LAYOUT_SIZE = 0xB5;
 
 const BOOT_LOADER_VERSION_OFFSET = 0x00C0;
 const BOOT_LOADER_VERSION_SIZE = 1;
@@ -33,6 +33,10 @@ const LAYOUT = {
   NAME: {
     offset: 0x05,
     size: 12,
+  },
+  TYPE: {
+    offset: 0xB0,
+    size: 4,
   },
   MOTOR_DIRECTION: {
     offset: 0x11,

--- a/src/utils/FourWay.js
+++ b/src/utils/FourWay.js
@@ -368,13 +368,14 @@ class FourWay {
         info.layoutSize = source.getLayoutSize();
         info.settingsArray = (await this.read(eepromOffset, info.layoutSize)).params;
         info.settings = Convert.arrayToSettingsObject(info.settingsArray, info.layout);
-
+        
         /**
          * If not AM32, then very likely BLHeli_32, even if not - we can't
          * handle it.
          */
         const validNames = source.getValidNames();
-        if(!validNames.includes(info.settings.NAME)) {
+
+        if(info.settings.TYPE !== 'AM32' && !validNames.includes(info.settings.NAME)) {
           source = null;
 
           info.settings.NAME = 'BLHeli_32';


### PR DESCRIPTION
This changes the AM32 evaluation to a TYPE eeprom value from the ESC.

This requires https://github.com/AlkaMotors/AM32-MultiRotor-ESC-firmware/pull/100