### PR TITLE
fix am32 flashing error when not all 4 ESCs are connected

### DIFF
--- a/src/Containers/App/index.jsx
+++ b/src/Containers/App/index.jsx
@@ -283,7 +283,8 @@ class App extends Component {
       if(result) {
         result.index = target;
         result.ref = React.createRef();
-        individual[target] = result;
+        const targetEscInIndividual = escs.individual.find((esc) => esc.index === target);
+        individual[targetEscInIndividual] = result;
 
         await this.setEscs({ individual });
       } else {

--- a/src/Containers/App/index.jsx
+++ b/src/Containers/App/index.jsx
@@ -283,8 +283,8 @@ class App extends Component {
       if(result) {
         result.index = target;
         result.ref = React.createRef();
-        const targetEscInIndividual = escs.individual.find((esc) => esc.index === target);
-        individual[targetEscInIndividual] = result;
+        const individualIndex = escs.individual.findIndex((esc) => esc.index === target);
+        individual[individualIndex] = result;
 
         await this.setEscs({ individual });
       } else {

--- a/src/utils/FourWay.js
+++ b/src/utils/FourWay.js
@@ -1153,11 +1153,15 @@ class FourWay {
          * The vector table will not change between firmware versions, but will be
          * different for different MCUs
          */
+        //call initFlash before call to read, or the read will read from the last (the 4th) esc
+        await this.initFlash(target);
         const newVectorStartBytes = flash.subarray(firmwareStart, firmwareStart + 4);
         const currentVectorStartBytes = (await this.read(firmwareStart, 4, 10)).params;
 
         if (!compare(newVectorStartBytes, currentVectorStartBytes)) {
-          throw new InvalidHexFileError('Invalid hex file');
+          if (!force) {
+            throw new InvalidHexFileError('Invalid hex file');
+          }
         }
 
         if (firmwareStart) {

--- a/src/utils/FourWay.js
+++ b/src/utils/FourWay.js
@@ -1146,20 +1146,20 @@ class FourWay {
         const endAddress = parsed.data[parsed.data.length - 1].address + parsed.data[parsed.data.length - 1].bytes;
         const flash = Flash.fillImage(parsed, endAddress - flashOffset, flashOffset);
 
-        /**
-         * Compare the first 4 bytes of the vector table of the firmware to be flashed
-         * against the currently flashed firmware.
-         *
-         * The vector table will not change between firmware versions, but will be
-         * different for different MCUs
-         */
-        //call initFlash before call to read, or the read will read from the last (the 4th) esc
-        await this.initFlash(target);
-        const newVectorStartBytes = flash.subarray(firmwareStart, firmwareStart + 4);
-        const currentVectorStartBytes = (await this.read(firmwareStart, 4, 10)).params;
+        if (!force) {
+          /**
+           * Compare the first 4 bytes of the vector table of the firmware to be flashed
+           * against the currently flashed firmware.
+           *
+           * The vector table will not change between firmware versions, but will be
+           * different for different MCUs
+           */
+          //call initFlash before call to read, or the read will read from the last (the 4th) esc
+          await this.initFlash(target);
+          const newVectorStartBytes = flash.subarray(firmwareStart, firmwareStart + 4);
+          const currentVectorStartBytes = (await this.read(firmwareStart, 4, 10)).params;
 
-        if (!compare(newVectorStartBytes, currentVectorStartBytes)) {
-          if (!force) {
+          if (!compare(newVectorStartBytes, currentVectorStartBytes)) {
             throw new InvalidHexFileError('Invalid hex file');
           }
         }


### PR DESCRIPTION
Fix for the following errors.
When only connect one ESC to fc, the flashing process will fail.
When flashing am32 for the first time, it will fail even with ignore mcu & layout.