### PR TITLE
add new pin for mcus with pa6 as the signal pin

### DIFF
--- a/src/sources/AM32/eeprom.js
+++ b/src/sources/AM32/eeprom.js
@@ -1,7 +1,7 @@
 const BOOT_LOADER_PINS = {
   PA2: 0x02,
   PB4: 0x14,
-  PA6: 0x06
+  PA6: 0x06,
 };
 
 const RESET_DELAY_MS = 5000;

--- a/src/sources/AM32/eeprom.js
+++ b/src/sources/AM32/eeprom.js
@@ -1,6 +1,7 @@
 const BOOT_LOADER_PINS = {
   PA2: 0x02,
   PB4: 0x14,
+  PA6: 0x06
 };
 
 const RESET_DELAY_MS = 5000;


### PR DESCRIPTION
New mcu uses PA6 as signal pin