### PR TITLE
pad 0 if sub_version is < 10

### DIFF
--- a/src/sources/AM32/index.js
+++ b/src/sources/AM32/index.js
@@ -40,7 +40,7 @@ class AM32Source extends GithubSource {
     const settings = flash.settings;
     let revision = 'Unsupported/Unrecognized';
     if(settings.MAIN_REVISION !== undefined && settings.SUB_REVISION !== undefined) {
-      revision = `${settings.MAIN_REVISION}.${settings.SUB_REVISION}`;
+      revision = `${settings.MAIN_REVISION}.${settings.SUB_REVISION > 9 ? '' : '0'}${settings.SUB_REVISION}`;
     }
 
     if(make === 'NOT READY') {


### PR DESCRIPTION
version is written as int into hex, to follow AM32 versioning schema, we need to pad a 0 if sub_revision is < 10