### PR TITLE
Update index.jsx

### DIFF
--- a/src/Components/PortPicker/CompatibilityWarning/index.jsx
+++ b/src/Components/PortPicker/CompatibilityWarning/index.jsx
@@ -10,7 +10,17 @@ function CompatibilityWarning() {
       </b>
 
       {' '}
-      is not supported on your browser. Make sure you&apos;re running an up to date Chromium based browser like
+      is not supported on your browser, install 
+      
+      {' '}
+      <a
+        href="https://github.com/kuba2k2/firefox-webserial"
+        rel="noreferrer"
+        target="_blank"
+      >
+        firefox webserial
+      </a>
+      . Or switch to an up to date Chromium based browser like
 
       {' '}
 


### PR DESCRIPTION
added the webserial extension link thats allow esc-configurator to work perfectly on the only not chomium based browser (firefox). I tested it on a fresh ubuntu install and it worked perfectly with esc configurator. 
here the extension github: https://github.com/kuba2k2/firefox-webserial